### PR TITLE
manifests: Add role for csi-resizer

### DIFF
--- a/manifests/storpool-csi-controllerplugin-rbac.yaml
+++ b/manifests/storpool-csi-controllerplugin-rbac.yaml
@@ -81,3 +81,42 @@ roleRef:
   kind: ClusterRole
   name: csi-provisioner-role
   apiGroup: rbac.authorization.k8s.io
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattributesclasses"]
+    verbs: ["get", "list", "watch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-binding
+subjects:
+  - kind: ServiceAccount
+    name: storpool-csi-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-resizer-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Fixes error logged every minute from csi-resizer container:

```
W0605 13:00:04.161769       1 reflector.go:533] k8s.io/client-go/informers/factory.go:150: failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:kube-system:storpool-csi-controller-sa" cannot list resource "pods" in API group "" at the cluster scope
E0605 13:00:04.161829       1 reflector.go:148] k8s.io/client-go/informers/factory.go:150: Failed to watch *v1.Pod: failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:kube-system:storpool-csi-controller-sa" cannot list resource "pods" in API group "" at the cluster scope
```

Image: registry.k8s.io/sig-storage/csi-resizer:v1.8.0